### PR TITLE
fix(ansible, systemd): fixed the executable path for micromamba in systemd context

### DIFF
--- a/ansible/rag-demo.yml
+++ b/ansible/rag-demo.yml
@@ -176,7 +176,14 @@
      become: true
      become_user: root
      ansible.builtin.shell:
-      cmd: ln -s {{ working_directory }}/repo/systemd/rag-demo.service /etc/systemd/system/rag-demo.service
+      cmd: ln -s {{ working_directory }}/repo/systemd/rag-demo.service /etc/systemd/system/rag-demo.service -f
+ 
+   - name: Make micromamba gloablly available
+     when: auto_start and micromamba_location != "/usr/local/bin/micromamba"
+     become: true
+     become_user: root
+     ansible.builtin.shell:
+      cmd: ln -s {{ micromamba_location }} /usr/local/bin/micromamba -f
 
    - name: Start Systemd Service
      when: auto_start


### PR DESCRIPTION
Executing from an initprocess (systemd) which does not have the {{ ansible_user }} local $PATH variable ==> micromamba_location might not be in the path of the rag-demo unit.
To resolve this issue an additional step was added to the playbook, which creates a symlink from /usr/local/bin/micromamba  to the micromamba_location.