### PR TITLE
fix(ansible): added support for new port changes in older ansible

### DIFF
--- a/systemd/run_rag_demo.sh
+++ b/systemd/run_rag_demo.sh
@@ -2,5 +2,12 @@
 set -eou pipefail
 
 # NOTE: the relative path is important for run_model to find the DB (in its current state.)
+port="%{ demo_port }%"
+if [ "$port" -eq "$port" ]; then
+    echo "port given."
+else
+    echo "using standard port 7680"
+    port=7680
+fi
 cd %{ working_directory }%/repo
-RAG_MODEL_PATH=%{ working_directory }%/model/%{ model_name }% RAG_PORT=%{ demo_port }% %{ micromamba_location }% run -n rag-demo -r %{ conda_dir }% python run_model.py
+RAG_MODEL_PATH=%{ working_directory }%/model/%{ model_name }% RAG_PORT="$port" %{ micromamba_location }% run -n rag-demo -r %{ conda_dir }% python run_model.py


### PR DESCRIPTION
The ansible script which is taken from a fixed commit now does not need to set the demo_port in the systemd run script for it to work.