### PR TITLE
fix(ci/cd): pinned versions

### DIFF
--- a/ansible/rag-environment.yml
+++ b/ansible/rag-environment.yml
@@ -5,10 +5,10 @@ channels:
 dependencies:
   - python=%{ python_version }%
   - pip
-  - httptools
+  - httptools~=0.5.0
   - onnxruntime>=1.14.1
   - pandas<1.6.0
-  - pytorch-cpu
-  - pyyaml
-  - scikit-learn
-  - tokenizers
+  - pytorch-cpu~=2.1.2
+  - pyyaml~=6.0.1
+  - scikit-learn~=1.3.0
+  - tokenizers~=0.15.2

--- a/ansible/requirements.txt
+++ b/ansible/requirements.txt
@@ -1,8 +1,8 @@
 ansible
-chromadb
-gradio==3.50.2
-langchain
-llama-cpp-python
-psutil
-sentence_transformers
-transformers
+chromadb~=0.6.3
+gradio~=3.50.2
+langchain~=0.3.23
+llama-cpp-python~=0.3.4
+psutil~=7.0.0
+sentence_transformers~=4.0.2
+transformers~=4.50.3


### PR DESCRIPTION
To ensure a working installation/deployment using the ansible script or other automations, all python package versions (for the application) were pinned to a known working state.